### PR TITLE
Using ActorRefFactory rather than ActorSystem to create temporary actors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "1.2-SNAPSHOT"
  
 scalaVersion := "2.10.1"
 
-scalacOptions  += "-feature"
+scalacOptions  ++= Seq("-feature", "-language:postfixOps")
  
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 


### PR DESCRIPTION
I believe ActorRefFactory is a more appropriate type than ActorSystem to pass into the amqp-client library.  This allows connections to be spawned from child actors, and does not require passing the ActorSystem to child Actors nor looking up the root system.
