### PR TITLE
Added couple optional parameters to RabbitMQConnection for:

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ libraryDependencies <<= scalaVersion { scala_version =>
         "com.rabbitmq"         % "amqp-client"          % "3.1.1",
         "com.typesafe.akka"    %% "akka-testkit"        % akkaVersion  % "test",
         "org.scalatest"        %% "scalatest"           % "1.9.1" % "test",
-        "junit"           	   % "junit"                % "4.11" % "test"
+        "junit"           	   % "junit"                % "4.11" % "test",
+        "com.typesafe.akka"    %  "akka-slf4j_2.10"     % akkaVersion,
+        "ch.qos.logback"       %  "logback-classic"     % "1.0.0"
     )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositori
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0-SNAPSHOT")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")

--- a/src/test/scala/com/github.sstone/amqp/ConnectionOwnerSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ConnectionOwnerSpec.scala
@@ -10,7 +10,7 @@ import akka.pattern.gracefulStop
 import akka.util.Timeout
 import concurrent.duration._
 import concurrent.Await
-import com.rabbitmq.client.Channel
+import com.rabbitmq.client.{Address, Channel}
 import ConnectionOwner.CreateChannel
 
 @RunWith(classOf[JUnitRunner])
@@ -20,6 +20,21 @@ class ConnectionOwnerSpec extends TestKit(ActorSystem("TestSystem")) with WordSp
   "ConnectionOwner" should {
     "provide channels for many child actors" in {
       val conn = new RabbitMQConnection(vhost = "/", name = "conn")
+      conn.waitForConnection.await()
+      val actors = 1000
+      for (i <- 0 until actors) {
+        val p = TestProbe()
+        p.send(conn.owner, CreateChannel)
+        p.expectMsgClass(2.second, classOf[Channel])
+      }
+      Await.result(gracefulStop(conn.owner, 5 seconds), 6 seconds)
+    }
+    "connect even if the default host is unavailable" in {
+      val conn = new RabbitMQConnection(host = "fake-host", vhost = "/", name = "conn",
+        addresses = Some( Array(
+          new Address("another.fake.host"),
+          new Address("localhost")
+        )))
       conn.waitForConnection.await()
       val actors = 1000
       for (i <- 0 until actors) {


### PR DESCRIPTION
- Alternative list of addresses when RMQ works in HA mode
- Custom ExecutionService for consumer threads

Actually I added couple parameters from this part of the [RabbitMQ API](http://www.rabbitmq.com/api-guide.html#advanced-connection). If this change can be integrated with 1.3 - that would be great, I tried but did not find where the version is stored.

Thanks
