### PR TITLE
Add Get capability to the ChannelOwner.

### DIFF
--- a/src/main/scala/com/github.sstone/amqp/Amqp.scala
+++ b/src/main/scala/com/github.sstone/amqp/Amqp.scala
@@ -110,6 +110,8 @@ object Amqp {
 
   case class Record(request: Request) extends Request
 
+  case class Get(queue: String, autoAck: Boolean) extends Request
+
   /**
    * sent back by a publisher when the request was processed successfully
    * @param request original request

--- a/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
@@ -177,6 +177,10 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
       log.debug("unbinding queue {} to key {} on exchange {}", queue, routingKey, exchange)
       stay replying withChannel(channel, request)(c => c.queueUnbind(queue, exchange, routingKey, args))
     }
+    case Event(request@Get(queue, autoAck), Connected(channel)) => {
+      log.debug("getting from queue {} autoAck {}", queue, autoAck)
+      stay replying withChannel(channel, request)(c => c.basicGet(queue, autoAck))
+    }
   }
 
   whenUnhandled {


### PR DESCRIPTION
For completeness as a RabbitMQ client wrapper.
