### PR TITLE
Remove temporary watcher as a listener when it is stopped

### DIFF
--- a/src/main/scala/com/github.sstone/amqp/Amqp.scala
+++ b/src/main/scala/com/github.sstone/amqp/Amqp.scala
@@ -84,8 +84,6 @@ object Amqp {
 
   case class AddStatusListener(listener: ActorRef) extends Request
 
-  case class RemoveStatusListener() extends Request
-
   case class AddReturnListener(listener: ActorRef) extends Request
 
   case class AddShutdownListener(listener: ActorRef) extends Request
@@ -199,7 +197,6 @@ object Amqp {
       def receive = {
         case ChannelOwner.Connected | ConnectionOwner.Connected =>
           onConnected()
-          channelOrConnectionActor ! RemoveStatusListener()
           context.stop(self)
       }
     }))

--- a/src/main/scala/com/github.sstone/amqp/Amqp.scala
+++ b/src/main/scala/com/github.sstone/amqp/Amqp.scala
@@ -84,6 +84,8 @@ object Amqp {
 
   case class AddStatusListener(listener: ActorRef) extends Request
 
+  case class RemoveStatusListener() extends Request
+
   case class AddReturnListener(listener: ActorRef) extends Request
 
   case class AddShutdownListener(listener: ActorRef) extends Request
@@ -197,6 +199,7 @@ object Amqp {
       def receive = {
         case ChannelOwner.Connected | ConnectionOwner.Connected =>
           onConnected()
+          channelOrConnectionActor ! RemoveStatusListener()
           context.stop(self)
       }
     }))

--- a/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
@@ -185,6 +185,7 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
       requestLog :+= request
     }
     case AddStatusListener(actor) => statusListener = Some(actor)
+    case RemoveStatusListener() => statusListener = None
   }
 
   def connected(channel: Channel, forwarder: ActorRef): Receive = LoggingReceive {
@@ -197,6 +198,7 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
       statusListener = Some(actor)
       actor ! Connected
     }
+    case RemoveStatusListener() => statusListener = None
     case request: Request => {
       forwarder forward request
     }

--- a/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
@@ -159,9 +159,15 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
 
   override def preStart() = context.parent ! ConnectionOwner.CreateChannel
 
-  override def unhandled(message: Any): Unit = {
-    log.warning(s"unhandled message $message")
-    super.unhandled(message)
+  override def unhandled(message: Any): Unit = message match {
+    case Terminated(actor) if statusListener == Some(actor) => {
+      context.unwatch(actor)
+      statusListener = None
+    }
+    case _ => {
+      log.warning(s"unhandled message $message")
+      super.unhandled(message)
+    }
   }
 
   def onChannel(channel: Channel, forwarder: ActorRef): Unit = {
@@ -184,8 +190,7 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
     case Record(request: Request) => {
       requestLog :+= request
     }
-    case AddStatusListener(actor) => statusListener = Some(actor)
-    case RemoveStatusListener() => statusListener = None
+    case AddStatusListener(actor) => addStatusListener(actor)
   }
 
   def connected(channel: Channel, forwarder: ActorRef): Receive = LoggingReceive {
@@ -194,11 +199,10 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
       requestLog :+= request
       self forward request
     }
-    case AddStatusListener(actor) => {
-      statusListener = Some(actor)
-      actor ! Connected
+    case AddStatusListener(listener) => {
+      addStatusListener(listener)
+      listener ! Connected
     }
-    case RemoveStatusListener() => statusListener = None
     case request: Request => {
       forwarder forward request
     }
@@ -209,5 +213,11 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
       statusListener.map(a => a ! Disconnected)
       context.become(disconnected)
     }
+  }
+
+  private def addStatusListener(listener: ActorRef) {
+    statusListener.map(context.unwatch)
+    context.watch(listener)
+    statusListener = Some(listener)
   }
 }

--- a/src/main/scala/com/github.sstone/amqp/ConnectionOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ConnectionOwner.scala
@@ -199,6 +199,8 @@ class ConnectionOwner(connFactory: ConnectionFactory,
      */
     case AddStatusListener(listener) => statusListener = Some(listener)
 
+    case RemoveStatusListener() => statusListener = None
+
     /**
      * create a "channel aware" child actor
      */
@@ -223,6 +225,7 @@ class ConnectionOwner(connFactory: ConnectionFactory,
       statusListener = Some(listener)
       listener ! Connected
     }
+    case RemoveStatusListener() => statusListener = None
     case Create(props, name) => {
       sender ! createChild(props, name)
     }

--- a/src/test/scala/com/github.sstone/amqp/ChannelOwnerSpec.scala
+++ b/src/test/scala/com/github.sstone/amqp/ChannelOwnerSpec.scala
@@ -3,8 +3,8 @@ package com.github.sstone.amqp
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 import akka.testkit.TestProbe
-import akka.actor.DeadLetter
-import java.util.concurrent.TimeUnit
+import akka.actor.{Props, Actor, DeadLetter}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 import concurrent.duration._
 import com.rabbitmq.client.AMQP.Queue
 import com.github.sstone.amqp.Amqp._
@@ -64,16 +64,22 @@ class ChannelOwnerSpec extends ChannelSpec  {
 
 
   "remove a status listener when it terminates" in {
+    val latch = new CountDownLatch(1)
+
+    val statusListenerProbe = system.actorOf(Props(new Actor {
+      def receive = {
+        case ChannelOwner.Connected => latch.countDown()
+        case _ => fail("Status listener did not detect channel connection")
+      }
+    }))
+
+    latch.await(3, TimeUnit.SECONDS)
+    channelOwner ! AddStatusListener(statusListenerProbe)
+
     val deadletterProbe = TestProbe()
     system.eventStream.subscribe(deadletterProbe.ref, classOf[DeadLetter])
 
-    val statusListenerProbe = TestProbe()
-
-    channelOwner ! AddStatusListener(statusListenerProbe.ref)
-
-    statusListenerProbe.expectMsg(3 seconds, ChannelOwner.Connected)
-
-    system.stop(statusListenerProbe.ref)
+    system.stop(statusListenerProbe)
 
     channelOwner ! DeclareQueue(QueueParameters("NO_SUCH_QUEUE", passive = true))
 


### PR DESCRIPTION
The temporary actor used as a watcher on the channel / connection remains as a status listener, even after it has been stopped. AFAICT this doesn't break anything, but it does mean we see dead lettered messages when a connection or channel closes.

This PR removes the listener when stopping the actor.
