### PR TITLE
Update sbt dependency versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,19 +4,19 @@ organization := "com.github.sstone"
  
 version := "1.3-SNAPSHOT"
  
-scalaVersion := "2.10.1"
+scalaVersion := "2.10.4"
 
 scalacOptions  ++= Seq("-feature", "-language:postfixOps")
  
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies <<= scalaVersion { scala_version => 
-    val akkaVersion   = "2.2.3"
+    val akkaVersion   = "2.3.2"
     Seq(
         "com.typesafe.akka"    %% "akka-actor"          % akkaVersion,
-        "com.rabbitmq"         % "amqp-client"          % "3.2.1",
+        "com.rabbitmq"         % "amqp-client"          % "3.3.1",
         "com.typesafe.akka"    %% "akka-testkit"        % akkaVersion  % "test",
-        "org.scalatest"        %% "scalatest"           % "1.9.1" % "test",
+        "org.scalatest"        %% "scalatest"           % "2.1.5" % "test",
         "junit"           	   % "junit"                % "4.11" % "test",
         "com.typesafe.akka"    %  "akka-slf4j_2.10"     % akkaVersion,
         "ch.qos.logback"       %  "logback-classic"     % "1.0.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")


### PR DESCRIPTION
This PR: 
- updates the dependency versions for sbt so that they are in line with the pom
- uses the latest Scala version
- updates the version of the gen-idea sbt plugin as I was experiencing problems with the old SNAPSHOT version
