### PR TITLE
Name the forwarder actor

### DIFF
--- a/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ChannelOwner.scala
@@ -181,7 +181,7 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
 
   def disconnected: Receive = LoggingReceive {
     case channel: Channel => {
-      val forwarder = context.actorOf(Props(new Forwarder(channel)))
+      val forwarder = context.actorOf(Props(new Forwarder(channel)), name = "forwarder")
       forwarder ! AddShutdownListener(self)
       forwarder ! AddReturnListener(self)
       onChannel(channel, forwarder)


### PR DESCRIPTION
Small change to name the forwarder actor, as we have found it useful when using the sbt console to see what actors we have and what they are up to.
