### PR TITLE
Fire ConnectionOwner.Disconnected event to its status listeners.

### DIFF
--- a/src/main/scala/com/github.sstone/amqp/ConnectionOwner.scala
+++ b/src/main/scala/com/github.sstone/amqp/ConnectionOwner.scala
@@ -169,6 +169,7 @@ class ConnectionOwner(connFactory: ConnectionFactory,
       case Success(channel) => sender ! channel
       case Failure(cause) => {
         log.error(cause, "cannot create channel")
+        statusListeners.map(a => a ! Disconnected)
         context.become(disconnected)
       }
     }
@@ -182,6 +183,7 @@ class ConnectionOwner(connFactory: ConnectionFactory,
     case Shutdown(cause) => {
       log.error(cause, "connection lost")
       connection = None
+      statusListeners.map(a => a ! Disconnected)
       context.children.foreach(_ ! Shutdown(cause))
       self ! 'connect
       context.become(disconnected)


### PR DESCRIPTION
ChannelOwner.scala already has a similiar behaviour.

I don't see why the ConnectionOwner shouldn't notify the status listeners that it is now disconnected.
